### PR TITLE
Add snowflake_file_format resource

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -71,6 +71,7 @@ func Provider() *schema.Provider {
 			"snowflake_account_grant":          resources.AccountGrant(),
 			"snowflake_database":               resources.Database(),
 			"snowflake_database_grant":         resources.DatabaseGrant(),
+			"snowflake_file_format":            resources.FileFormat(),
 			"snowflake_integration_grant":      resources.IntegrationGrant(),
 			"snowflake_managed_account":        resources.ManagedAccount(),
 			"snowflake_pipe":                   resources.Pipe(),

--- a/pkg/resources/file_format.go
+++ b/pkg/resources/file_format.go
@@ -42,13 +42,10 @@ var fileFormatSchema = map[string]*schema.Schema{
 		Description: "Specifies the format of the input files (for data loading) or output files (for data unloading). Depending on the format type, additional format-specific options can be specified.",
 		ForceNew:    true,
 		ValidateFunc: func(val interface{}, _ string) ([]string, []error) {
-			t, ok := val.(snowflake.FileFormatType)
-			if !ok {
-				return nil, []error{fmt.Errorf("%s is not a supported type", val)}
-			}
+			t := strings.ToLower(val.(string))
 
 			switch t {
-			case snowflake.Parquet:
+			case "parquet":
 				return nil, nil
 			default:
 				return nil, []error{fmt.Errorf("%s is not a supported type", val)}
@@ -66,13 +63,10 @@ var fileFormatSchema = map[string]*schema.Schema{
 		Default:     "auto",
 		Description: "Specifies the current compression algorithm for columns in the Parquet files.",
 		ValidateFunc: func(val interface{}, _ string) ([]string, []error) {
-			c, ok := val.(snowflake.Compression)
-			if !ok {
-				return nil, []error{fmt.Errorf("%s is not a supported compression algorithm", val)}
-			}
+			c := strings.ToLower(val.(string))
 
 			switch c {
-			case snowflake.AUTO, snowflake.LZO, snowflake.SNAPPY, snowflake.NONE:
+			case "auto", "lzo", "snappy", "none":
 				return nil, nil
 			default:
 				return nil, []error{fmt.Errorf("%s is not a supported compression algorithm", val)}

--- a/pkg/resources/file_format.go
+++ b/pkg/resources/file_format.go
@@ -1,0 +1,217 @@
+package resources
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/csv"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
+)
+
+const (
+	fileFormatIDDelimiter = '|'
+)
+
+var fileFormatSchema = map[string]*schema.Schema{
+	"name": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Specifies the identifier for the file format; must be unique for the schema in which the file format is created.",
+		ForceNew:    true, // TODO: Support RENAME TO
+	},
+	"database": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "The database in which to create the file format.",
+		ForceNew:    true,
+	},
+	"schema": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "The schema in which to create the file format.",
+		ForceNew:    true,
+	},
+	"type": {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Specifies the format of the input files (for data loading) or output files (for data unloading). Depending on the format type, additional format-specific options can be specified.",
+		ForceNew:    true,
+		ValidateFunc: func(val interface{}, _ string) ([]string, []error) {
+			t, ok := val.(snowflake.FileFormatType)
+			if !ok {
+				return nil, []error{fmt.Errorf("%s is not a supported type", val)}
+			}
+
+			switch t {
+			case snowflake.Parquet:
+				return nil, nil
+			default:
+				return nil, []error{fmt.Errorf("%s is not a supported type", val)}
+			}
+		},
+	},
+	"comment": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Specifies a comment for the file format.",
+	},
+	"compression": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Default:     "auto",
+		Description: "Specifies the current compression algorithm for columns in the Parquet files.",
+		ValidateFunc: func(val interface{}, _ string) ([]string, []error) {
+			c, ok := val.(snowflake.Compression)
+			if !ok {
+				return nil, []error{fmt.Errorf("%s is not a supported compression algorithm", val)}
+			}
+
+			switch c {
+			case snowflake.AUTO, snowflake.LZO, snowflake.SNAPPY, snowflake.NONE:
+				return nil, nil
+			default:
+				return nil, []error{fmt.Errorf("%s is not a supported compression algorithm", val)}
+			}
+		},
+	},
+	"binary_as_text": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Default:     true,
+		Description: "Boolean that specifies whether to interpret columns with no defined logical data type as UTF-8 text. When set to FALSE, Snowflake interprets these columns as binary data.",
+	},
+	"trim_space": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Default:     false,
+		Description: "Applied only when loading Parquet data into separate columns (i.e. using the MATCH_BY_COLUMN_NAME copy option or a COPY transformation). Boolean that specifies whether to remove leading and trailing white space from strings.",
+	},
+	"null_if": {
+		Type:        schema.TypeList,
+		Elem:        &schema.Schema{Type: schema.TypeString},
+		Optional:    true,
+		Default:     []string{"\\N"},
+		Description: "Applied only when loading Parquet data into separate columns (i.e. using the MATCH_BY_COLUMN_NAME copy option or a COPY transformation). String used to convert to and from SQL NULL. Snowflake replaces these strings in the data load source with SQL NULL.",
+	},
+}
+
+type fileFormatID struct {
+	DatabaseName   string
+	SchemaName     string
+	FileFormatName string
+}
+
+// String() takes in a stageID object and returns a pipe-delimited string:
+// DatabaseName|SchemaName|FileFormatName
+func (id *fileFormatID) String() (string, error) {
+	var buf bytes.Buffer
+	csvWriter := csv.NewWriter(&buf)
+	csvWriter.Comma = stageIDDelimiter
+	dataIdentifiers := [][]string{{id.DatabaseName, id.SchemaName, id.FileFormatName}}
+	err := csvWriter.WriteAll(dataIdentifiers)
+	if err != nil {
+		return "", err
+	}
+	strStageID := strings.TrimSpace(buf.String())
+	return strStageID, nil
+}
+
+// fileFormatIDFromString() takes in a pipe-delimited string: DatabaseName|SchemaName|FileFormatName
+// and returns a pointer to fileFormatID object
+func fileFormatIDFromString(stringID string) (*fileFormatID, error) {
+	reader := csv.NewReader(strings.NewReader(stringID))
+	reader.Comma = fileFormatIDDelimiter
+	lines, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("Not CSV compatible")
+	}
+
+	if len(lines) != 1 {
+		return nil, fmt.Errorf("1 line per file format")
+	}
+	if len(lines[0]) != 3 {
+		return nil, fmt.Errorf("3 fields allowed")
+	}
+
+	return &fileFormatID{
+		DatabaseName:   lines[0][0],
+		SchemaName:     lines[0][1],
+		FileFormatName: lines[0][2],
+	}, nil
+}
+
+// FileFormat returns a pointer to the resource representing a file format
+func FileFormat() *schema.Resource {
+	return &schema.Resource{
+		Read: ReadFileFormat,
+
+		Schema: fileFormatSchema,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+	}
+}
+
+// ReadStage implements schema.ReadFunc
+func ReadFileFormat(data *schema.ResourceData, metadata interface{}) error {
+	db := metadata.(*sql.DB)
+	fileFormatID, err := fileFormatIDFromString(data.Id())
+	if err != nil {
+		return err
+	}
+
+	builder := snowflake.FileFormat(fileFormatID.FileFormatName, fileFormatID.DatabaseName, fileFormatID.SchemaName)
+
+	ffData, err := snowflake.DescFileFormat(db, builder.Describe())
+	if err != nil {
+		return err
+	}
+
+	row := snowflake.QueryRow(db, builder.Show())
+	ffMeta, err := snowflake.ScanFileFormatShow(row)
+	if err != nil {
+		return err
+	}
+
+	if err := data.Set("name", ffMeta.Name); err != nil {
+		return err
+	}
+
+	if err := data.Set("database", ffMeta.DatabaseName); err != nil {
+		return err
+	}
+
+	if err := data.Set("schema", ffMeta.SchemaName); err != nil {
+		return err
+	}
+
+	if err := data.Set("commnet", ffMeta.Comment); err != nil {
+		return err
+	}
+
+	if err := data.Set("type", string(ffData.Type)); err != nil {
+		return err
+	}
+
+	if err := data.Set("compression", string(ffData.Compression)); err != nil {
+		return err
+	}
+
+	if err := data.Set("binary_as_text", ffData.BinaryAsText); err != nil {
+		return err
+	}
+
+	if err := data.Set("trim_space", ffData.TrimSpace); err != nil {
+		return err
+	}
+
+	if err := data.Set("null_if", ffData.NullIf); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/resources/file_format_test.go
+++ b/pkg/resources/file_format_test.go
@@ -1,0 +1,37 @@
+package resources_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/provider"
+	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources"
+	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
+)
+
+func TestFileFormat(t *testing.T) {
+	r := require.New(t)
+	err := resources.FileFormat().InternalValidate(provider.Provider().Schema, true)
+	r.NoError(err)
+}
+
+func TestFileFormatRead(t *testing.T) {
+	r := require.New(t)
+
+	data := schema.TestResourceDataRaw(t, resources.FileFormat().Schema, map[string]interface{}{
+		"name":     "test_file_format",
+		"database": "test_db",
+		"schema":   "test_schema",
+		"type":     "parquet",
+		"comment":  "This is a test",
+	})
+	r.NotNil(data)
+
+	testhelpers.WithMockDb(t, func(db *sql.DB, sqlmock sqlmock.Sqlmock) {
+		_ = sqlmock.ExpectExec(``)
+	})
+}

--- a/pkg/resources/file_format_test.go
+++ b/pkg/resources/file_format_test.go
@@ -2,6 +2,8 @@ package resources_test
 
 import (
 	"database/sql"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -11,6 +13,14 @@ import (
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/provider"
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/resources"
 	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/testhelpers"
+)
+
+const (
+	fileFormatName = "test_file_format"
+	databaseName   = "test_db"
+	schemaName     = "test_schema"
+	fileFormatType = "parquet"
+	comment        = "This is a test"
 )
 
 func TestFileFormat(t *testing.T) {
@@ -23,15 +33,64 @@ func TestFileFormatRead(t *testing.T) {
 	r := require.New(t)
 
 	data := schema.TestResourceDataRaw(t, resources.FileFormat().Schema, map[string]interface{}{
-		"name":     "test_file_format",
-		"database": "test_db",
-		"schema":   "test_schema",
-		"type":     "parquet",
-		"comment":  "This is a test",
+		"name":     fileFormatName,
+		"database": databaseName,
+		"schema":   schemaName,
+		"type":     fileFormatType,
+		"comment":  comment,
 	})
+	data.SetId(strings.Join([]string{databaseName, schemaName, fileFormatName}, "|"))
 	r.NotNil(data)
 
 	testhelpers.WithMockDb(t, func(db *sql.DB, sqlmock sqlmock.Sqlmock) {
-		_ = sqlmock.ExpectExec(``)
+		expectReadFileFormat(sqlmock)
+
+		err := resources.ReadFileFormat(data, db)
+		r.NoError(err)
 	})
+}
+
+func TestFileFormatCreate(t *testing.T) {
+	r := require.New(t)
+
+	data := schema.TestResourceDataRaw(t, resources.FileFormat().Schema, map[string]interface{}{
+		"name":     fileFormatName,
+		"database": databaseName,
+		"schema":   schemaName,
+		"type":     fileFormatType,
+		"comment":  comment,
+	})
+	r.NotNil(data)
+
+	testhelpers.WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
+		mock.ExpectExec(
+			fmt.Sprintf(
+				`^CREATE FILE FORMAT "%v"."%v"."%v" TYPE = "%v" COMMENT = "%v" BINARY_AS_TEXT = true TRIM_SPACE = false$`,
+				databaseName, schemaName, fileFormatName, fileFormatType, comment,
+			),
+		).WillReturnResult(sqlmock.NewResult(1, 1))
+
+		expectReadFileFormat(mock)
+
+		err := resources.CreateFileFormat(data, db)
+		r.NoError(err)
+	})
+}
+
+func expectReadFileFormat(sqlmock sqlmock.Sqlmock) {
+	showRows := sqlmock.NewRows([]string{
+		"format_options", "created_on", "name", "database_name", "schema_name", "type", "owner", "comment",
+	}).AddRow("{}", "2000-01-01 00:00:00.000 +0000", fileFormatName, databaseName, schemaName, fileFormatType, "SYSADMIN", comment)
+	sqlmock.ExpectQuery(fmt.Sprintf(`^SHOW FILE FORMATS LIKE '%v' IN DATABASE "%v"$`, fileFormatName, databaseName)).
+		WillReturnRows(showRows)
+
+	descRows := sqlmock.NewRows([]string{
+		"property", "property_type", "property_value", "property_default",
+	}).AddRow("TYPE", "String", fileFormatType, "CSV").
+		AddRow("TRIM_SPACE", "Boolean", "false", "false").
+		AddRow("NULL_IF", "List", `["\\N","NULL",""]`, `["\\N"]`).
+		AddRow("COMPRESSION", "String", "AUTO", "AUTO").
+		AddRow("BINARY_AS_TEXT", "Boolean", "true", "true")
+	sqlmock.ExpectQuery(fmt.Sprintf(`^DESCRIBE FILE FORMAT "%v"."%v"."%v"$`, databaseName, schemaName, fileFormatName)).
+		WillReturnRows(descRows)
 }

--- a/pkg/snowflake/file_format.go
+++ b/pkg/snowflake/file_format.go
@@ -1,0 +1,136 @@
+package snowflake
+
+import (
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/jmoiron/sqlx"
+)
+
+type FileFormatType string
+
+const (
+	CSV     FileFormatType = "csv" // TODO: Add support for this
+	Parquet FileFormatType = "parquet"
+)
+
+type Compression string
+
+const (
+	AUTO   Compression = "auto"
+	LZO    Compression = "lzo"
+	SNAPPY Compression = "snappy"
+	NONE   Compression = "none"
+)
+
+// FileFormatBuilder abstracts the creation of SQL queries for a Snowflake file format
+type FileFormatBuilder struct {
+	name   string
+	db     string
+	schema string
+}
+
+// QualifiedName prepends the db and schema and escapes everything nicely
+func (fb *FileFormatBuilder) QualifiedName() string {
+	var n strings.Builder
+
+	n.WriteString(fmt.Sprintf(`"%v"."%v"."%v"`, fb.db, fb.schema, fb.name))
+
+	return n.String()
+}
+
+// FileFormat returns a pointer to a Builder that abstracts the DDL operations for a stage.
+//
+// Supported DDL operations are:
+//   - DESCRIBE FILE FORMAT
+//
+// [Snowflake Reference](https://docs.snowflake.com/en/sql-reference/ddl-stage.html#file-format-management)
+func FileFormat(name, db, schema string) *FileFormatBuilder {
+	return &FileFormatBuilder{
+		name:   name,
+		db:     db,
+		schema: schema,
+	}
+}
+
+// Describe returns the SQL query that will describe a file format.
+func (fb *FileFormatBuilder) Describe() string {
+	return fmt.Sprintf(`DESCRIBE FILE FORMAT %v`, fb.QualifiedName())
+}
+
+// Show returns the SQL query that will show a file format.
+func (fb *FileFormatBuilder) Show() string {
+	return fmt.Sprintf(`SHOW STAGES LIKE '%v' IN DATABASE "%v"`, fb.name, fb.db)
+}
+
+type fileFormatMetadata struct {
+	Name         *string `db:"name"`
+	DatabaseName *string `db:"database_name"`
+	SchemaName   *string `db:"schema_name"`
+	Comment      *string `db:"comment"`
+}
+
+// ScanFileFormatShow scans the given SQL row and returns the parsed file format metadata.
+func ScanFileFormatShow(row *sqlx.Row) (*fileFormatMetadata, error) {
+	metadata := &fileFormatMetadata{}
+	err := row.StructScan(metadata)
+	return metadata, err
+}
+
+type fileFormatData struct {
+	Type         FileFormatType
+	Compression  Compression
+	BinaryAsText bool
+	TrimSpace    bool
+	NullIf       []string
+}
+
+type descFileFormatRow struct {
+	Property        string `db:"property"`
+	PropertyType    string `db:"property_type"`
+	PropertyValue   string `db:"property_value"`
+	PropertyDefault string `db:"property_default"`
+}
+
+// DescFileFormat queries the file format with a describe and returns the file format data.
+func DescFileFormat(db *sql.DB, query string) (*fileFormatData, error) {
+	rows, err := Query(db, query)
+	if err != nil {
+		return &fileFormatData{}, err
+	}
+	defer rows.Close()
+
+	result := &fileFormatData{}
+	for rows.Next() {
+		row := &descFileFormatRow{}
+		if err := rows.StructScan(row); err != nil {
+			return &fileFormatData{}, err
+		}
+
+		switch row.Property {
+		case "TYPE":
+			result.Type = FileFormatType(row.PropertyValue)
+		case "COMPRESSION":
+			result.Compression = Compression(row.PropertyValue)
+		case "BINARY_AS_TEXT":
+			v, err := strconv.ParseBool(row.PropertyValue)
+			if err != nil {
+				return &fileFormatData{}, err
+			}
+			result.BinaryAsText = v
+		case "TRIM_SPACE":
+			v, err := strconv.ParseBool(row.PropertyValue)
+			if err != nil {
+				return &fileFormatData{}, err
+			}
+			result.TrimSpace = v
+		case "NULL_IF":
+			strs := strings.Trim(row.PropertyValue, "[\"]")
+			result.NullIf = strings.Split(strs, ",")
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/snowflake/file_format.go
+++ b/pkg/snowflake/file_format.go
@@ -87,6 +87,10 @@ func (fb *FileFormatBuilder) Create() string {
 	builder.WriteString(`CREATE FILE FORMAT `)
 	builder.WriteString(fb.QualifiedName())
 
+	builder.WriteString(fmt.Sprintf(` BINARY_AS_TEXT = %v`, fb.binaryAsText))
+
+	builder.WriteString(fmt.Sprintf(` TRIM_SPACE = %v`, fb.trimSpace))
+
 	if fb.fileFormatType != "" {
 		builder.WriteString(fmt.Sprintf(` TYPE = "%v"`, fb.fileFormatType))
 	}
@@ -98,10 +102,6 @@ func (fb *FileFormatBuilder) Create() string {
 	if fb.compression != "" {
 		builder.WriteString(fmt.Sprintf(` COMPRESSION = "%v"`, fb.compression))
 	}
-
-	builder.WriteString(fmt.Sprintf(` BINARY_AS_TEXT = %v`, fb.binaryAsText))
-
-	builder.WriteString(fmt.Sprintf(` TRIM_SPACE = %v`, fb.trimSpace))
 
 	if len(fb.nullIf) > 0 {
 		nulls := make([]string, len(fb.nullIf))
@@ -116,12 +116,12 @@ func (fb *FileFormatBuilder) Create() string {
 
 // ChangeComment returns the SQL query that will update the comment on the file format.
 func (fb *FileFormatBuilder) ChangeComment(comment string) string {
-	return fmt.Sprintf(`ALTER FILE FORMAT %v SET COMMENT = '%v'`, fb.QualifiedName(), comment)
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET COMMENT = "%v"`, fb.QualifiedName(), comment)
 }
 
 // ChangeComment returns the SQL query that will update the compression on the file format.
 func (fb *FileFormatBuilder) ChangeCompression(compression string) string {
-	return fmt.Sprintf(`ALTER FILE FORMAT %v SET COMPRESSION = '%v'`, fb.QualifiedName(), compression)
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET COMPRESSION = "%v"`, fb.QualifiedName(), compression)
 }
 
 // ChangeComment returns the SQL query that will update binary as text on the file format.

--- a/pkg/snowflake/file_format.go
+++ b/pkg/snowflake/file_format.go
@@ -84,7 +84,7 @@ func FileFormat(name, db, schema string) *FileFormatBuilder {
 // Create returns the SQL query that will create a new file format.
 func (fb *FileFormatBuilder) Create() string {
 	builder := strings.Builder{}
-	builder.WriteString(`CREATE FILE FORMAT`)
+	builder.WriteString(`CREATE FILE FORMAT `)
 	builder.WriteString(fb.QualifiedName())
 
 	if fb.fileFormatType != "" {

--- a/pkg/snowflake/file_format.go
+++ b/pkg/snowflake/file_format.go
@@ -9,22 +9,6 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-type FileFormatType string
-
-const (
-	CSV     FileFormatType = "csv" // TODO: Add support for this
-	Parquet FileFormatType = "parquet"
-)
-
-type Compression string
-
-const (
-	AUTO   Compression = "auto"
-	LZO    Compression = "lzo"
-	SNAPPY Compression = "snappy"
-	NONE   Compression = "none"
-)
-
 // FileFormatBuilder abstracts the creation of SQL queries for a Snowflake file format
 type FileFormatBuilder struct {
 	name           string
@@ -155,8 +139,8 @@ func ScanFileFormatShow(row *sqlx.Row) (*fileFormatMetadata, error) {
 }
 
 type fileFormatData struct {
-	Type         FileFormatType
-	Compression  Compression
+	Type         string
+	Compression  string
 	BinaryAsText bool
 	TrimSpace    bool
 	NullIf       []string
@@ -186,9 +170,9 @@ func DescFileFormat(db *sql.DB, query string) (*fileFormatData, error) {
 
 		switch row.Property {
 		case "TYPE":
-			result.Type = FileFormatType(row.PropertyValue)
+			result.Type = row.PropertyValue
 		case "COMPRESSION":
-			result.Compression = Compression(row.PropertyValue)
+			result.Compression = row.PropertyValue
 		case "BINARY_AS_TEXT":
 			v, err := strconv.ParseBool(row.PropertyValue)
 			if err != nil {

--- a/pkg/snowflake/file_format.go
+++ b/pkg/snowflake/file_format.go
@@ -114,6 +114,35 @@ func (fb *FileFormatBuilder) Create() string {
 	return builder.String()
 }
 
+// ChangeComment returns the SQL query that will update the comment on the file format.
+func (fb *FileFormatBuilder) ChangeComment(comment string) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET COMMENT = '%v'`, fb.QualifiedName(), comment)
+}
+
+// ChangeComment returns the SQL query that will update the compression on the file format.
+func (fb *FileFormatBuilder) ChangeCompression(compression string) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET COMPRESSION = '%v'`, fb.QualifiedName(), compression)
+}
+
+// ChangeComment returns the SQL query that will update binary as text on the file format.
+func (fb *FileFormatBuilder) ChangeBinaryAsText(binaryAsText bool) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET BINARY_AS_TEXT = %v`, fb.QualifiedName(), binaryAsText)
+}
+
+// ChangeComment returns the SQL query that will update trim space on the file format.
+func (fb *FileFormatBuilder) ChangeTrimSpace(trimSpace bool) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET TRIM_SPACE = %v`, fb.QualifiedName(), trimSpace)
+}
+
+// ChangeComment returns the SQL query that will update null if on the file format.
+func (fb *FileFormatBuilder) ChangeNullIf(nullIf []string) string {
+	nulls := make([]string, len(nullIf))
+	for i, n := range nullIf {
+		nulls[i] = fmt.Sprintf(`'%v'`, EscapeString(n))
+	}
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET NULL_IF = (%v)`, fb.QualifiedName(), strings.Join(nulls, ","))
+}
+
 // Drop returns the SQL query that will drop a file format.
 func (fb *FileFormatBuilder) Drop() string {
 	return fmt.Sprintf(`DROP FILE FORMAT %v`, fb.QualifiedName())

--- a/pkg/snowflake/file_format_test.go
+++ b/pkg/snowflake/file_format_test.go
@@ -1,0 +1,136 @@
+package snowflake_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/chanzuckerberg/terraform-provider-snowflake/pkg/snowflake"
+)
+
+const (
+	fileFormatName = "test_file_format"
+	databaseName   = "test_db"
+	schemaName     = "test_schema"
+	binaryAsText   = true
+	trimSpace      = true
+	fileFormatType = "parquet"
+	comment        = "This is a test"
+	compression    = "lzo"
+)
+
+func TestFileFormatCreate(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+
+	r.Equal(fmt.Sprintf(`"%v"."%v"."%v"`, databaseName, schemaName, fileFormatName), ff.QualifiedName())
+
+	query := fmt.Sprintf(
+		`CREATE FILE FORMAT "%v"."%v"."%v" BINARY_AS_TEXT = false TRIM_SPACE = false`,
+		databaseName, schemaName, fileFormatName,
+	)
+	r.Equal(query, ff.Create())
+
+	ff.WithBinaryAsText(binaryAsText)
+	query = fmt.Sprintf(
+		`CREATE FILE FORMAT "%v"."%v"."%v" BINARY_AS_TEXT = %v TRIM_SPACE = false`,
+		databaseName, schemaName, fileFormatName, binaryAsText,
+	)
+	r.Equal(query, ff.Create())
+
+	ff.WithTrimSpace(trimSpace)
+	query = fmt.Sprintf(
+		`CREATE FILE FORMAT "%v"."%v"."%v" BINARY_AS_TEXT = %v TRIM_SPACE = %v`,
+		databaseName, schemaName, fileFormatName, binaryAsText, trimSpace,
+	)
+	r.Equal(query, ff.Create())
+
+	ff.WithType(fileFormatType)
+	query += fmt.Sprintf(` TYPE = "%v"`, fileFormatType)
+	r.Equal(query, ff.Create())
+
+	ff.WithComment(comment)
+	query += fmt.Sprintf(` COMMENT = "%v"`, comment)
+	r.Equal(query, ff.Create())
+
+	ff.WithCompression(compression)
+	query += fmt.Sprintf(` COMPRESSION = "%v"`, compression)
+	r.Equal(query, ff.Create())
+
+	ff.WithNullIf([]string{`\N`, "NULL", ""})
+	query += fmt.Sprintf(` NULL_IF = ('\\N','NULL','')`)
+	r.Equal(query, ff.Create())
+}
+
+func TestFileFormatChangeComment(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET COMMENT = "%v"`, databaseName, schemaName, fileFormatName, comment),
+		ff.ChangeComment(comment),
+	)
+}
+
+func TestFileFormatChangeCompression(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET COMPRESSION = "%v"`, databaseName, schemaName, fileFormatName, compression),
+		ff.ChangeCompression(compression),
+	)
+}
+
+func TestFileFormatChangeBinaryAsText(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET BINARY_AS_TEXT = %v`, databaseName, schemaName, fileFormatName, binaryAsText),
+		ff.ChangeBinaryAsText(binaryAsText),
+	)
+}
+
+func TestFileFormatChangeTrimSpace(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET TRIM_SPACE = %v`, databaseName, schemaName, fileFormatName, trimSpace),
+		ff.ChangeTrimSpace(trimSpace),
+	)
+}
+
+func TestFileFormatChangeNullIf(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET NULL_IF = ('\\N','NULL','')`, databaseName, schemaName, fileFormatName),
+		ff.ChangeNullIf([]string{`\N`, "NULL", ""}),
+	)
+}
+
+func TestFileFormatDrop(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`DROP FILE FORMAT "%v"."%v"."%v"`, databaseName, schemaName, fileFormatName),
+		ff.Drop(),
+	)
+}
+
+func TestFileFormatDescribe(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`DESCRIBE FILE FORMAT "%v"."%v"."%v"`, databaseName, schemaName, fileFormatName),
+		ff.Describe(),
+	)
+}
+
+func TestFileFormatShow(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`SHOW FILE FORMATS LIKE '%v' IN DATABASE "%v"`, fileFormatName, databaseName),
+		ff.Show(),
+	)
+}


### PR DESCRIPTION
This PR adds `snowflake_file_format` resource with `parquet` type support.

## testing
```bash
$ cat main.tf
resource "snowflake_file_format" "file_format" {
  name = "PETERH_FF"
  database = "PETERH_DB"
  schema = "PUBLIC"
  type = "parquet"
  binary_as_text = true
  comment = "Terraform Snowflake provider development"
}
$ terraform plan
...
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # snowflake_file_format.file_format will be created
  + resource "snowflake_file_format" "file_format" {
      + binary_as_text = true
      + comment        = "Terraform Snowflake provider development"
      + database       = "PETERH_DB"
      + id             = (known after apply)
      + name           = "PETERH_FF"
      + schema         = "PUBLIC"
      + type           = "parquet"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
...
```

## References
* https://docs.snowflake.com/en/sql-reference/sql/create-file-format.html