### PR TITLE
Add CSV support to file format resource

### DIFF
--- a/pkg/resources/file_format.go
+++ b/pkg/resources/file_format.go
@@ -45,7 +45,7 @@ var fileFormatSchema = map[string]*schema.Schema{
 			t := strings.ToLower(val.(string))
 
 			switch t {
-			case "parquet":
+			case "csv", "parquet":
 				return nil, nil
 			default:
 				return nil, []error{fmt.Errorf("%s is not a supported type", val)}
@@ -60,13 +60,12 @@ var fileFormatSchema = map[string]*schema.Schema{
 	"compression": {
 		Type:        schema.TypeString,
 		Optional:    true,
-		Default:     "AUTO",
 		Description: "Specifies the current compression algorithm for columns in the Parquet files.",
 		ValidateFunc: func(val interface{}, _ string) ([]string, []error) {
 			c := strings.ToLower(val.(string))
 
 			switch c {
-			case "auto", "lzo", "snappy", "none":
+			case "auto", "brotli", "bz2", "deflate", "gzip", "lzo", "raw_deflate", "snappy", "zstd", "none":
 				return nil, nil
 			default:
 				return nil, []error{fmt.Errorf("%s is not a supported compression algorithm", val)}
@@ -76,13 +75,11 @@ var fileFormatSchema = map[string]*schema.Schema{
 	"binary_as_text": {
 		Type:        schema.TypeBool,
 		Optional:    true,
-		Default:     true,
 		Description: "Boolean that specifies whether to interpret columns with no defined logical data type as UTF-8 text. When set to FALSE, Snowflake interprets these columns as binary data.",
 	},
 	"trim_space": {
 		Type:        schema.TypeBool,
 		Optional:    true,
-		Default:     false,
 		Description: "Applied only when loading Parquet data into separate columns (i.e. using the MATCH_BY_COLUMN_NAME copy option or a COPY transformation). Boolean that specifies whether to remove leading and trailing white space from strings.",
 	},
 	"null_if": {
@@ -90,6 +87,106 @@ var fileFormatSchema = map[string]*schema.Schema{
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Optional:    true,
 		Description: "Applied only when loading Parquet data into separate columns (i.e. using the MATCH_BY_COLUMN_NAME copy option or a COPY transformation). String used to convert to and from SQL NULL. Snowflake replaces these strings in the data load source with SQL NULL.",
+	},
+	"record_delimiter": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "One or more singlebyte or multibyte characters that separate records in an input file (data loading) or unloaded file (data unloading).",
+	},
+	"field_delimiter": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "One or more singlebyte or multibyte characters that separate fields in an input file (data loading) or unloaded file (data unloading).",
+	},
+	"file_extension": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Specifies the extension for files unloaded to a stage.",
+	},
+	"skip_header": {
+		Type:        schema.TypeInt,
+		Optional:    true,
+		Description: "Number of lines at the start of the file to skip.",
+	},
+	"skip_blank_lines": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Boolean that specifies to skip any blank lines encountered in the data files.",
+	},
+	"date_format": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Defines the format of date values in the data files (data loading) or table (data unloading).",
+	},
+	"time_format": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Defines the format of time values in the data files (data loading) or table (data unloading).",
+	},
+	"timestamp_format": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Defines the format of timestamp values in the data files (data loading) or table (data unloading).",
+	},
+	"binary_format": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Defines the encoding format for binary input or output.",
+		ValidateFunc: func(val interface{}, _ string) ([]string, []error) {
+			c := strings.ToLower(val.(string))
+
+			switch c {
+			case "hex", "base64", "utf":
+				return nil, nil
+			default:
+				return nil, []error{fmt.Errorf("%s is not a supported binary format", val)}
+			}
+		},
+	},
+	"escape": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Single character string used as the escape character for field values.",
+	},
+	"escape_unenclosed_field": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Single character string used as the escape character for unenclosed field values only.",
+	},
+	"field_optionally_enclosed_by": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Character used to enclose strings.",
+	},
+	"error_on_column_count_mismatch": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Boolean that specifies whether to generate a parsing error if the number of delimited columns (i.e. fields) in an input file does not match the number of columns in the corresponding table.",
+	},
+	"replace_invalid_characters": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Boolean that specifies whether to replace invalid UTF-8 characters with the Unicode replacement character.",
+	},
+	"validate_utf8": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Boolean that specifies whether to validate UTF-8 character encoding in string column data.",
+	},
+	"empty_field_as_null": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "When loading data, specifies whether to insert SQL NULL for empty fields in an input file, which are represented by two successive delimiters (e.g. ,,). When unloading data, this option is used in combination with FIELD_OPTIONALLY_ENCLOSED_BY. When FIELD_OPTIONALLY_ENCLOSED_BY = NONE, setting EMPTY_FIELD_AS_NULL = FALSE specifies to unload empty strings in tables to empty string values without quotes enclosing the field values. If set to TRUE, FIELD_OPTIONALLY_ENCLOSED_BY must specify a character to enclose strings.",
+	},
+	"skip_byte_order_mark": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "Boolean that specifies whether to skip the BOM (byte order mark), if present in a data file.",
+	},
+	"encoding": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "String (constant) that specifies the character set of the source data when loading data into a table.",
 	},
 }
 
@@ -195,6 +292,78 @@ func CreateFileFormat(data *schema.ResourceData, meta interface{}) error {
 		builder.WithNullIf(nulls)
 	}
 
+	if v, ok := data.GetOk("record_delimiter"); ok {
+		builder.WithRecordDelimiter(v.(string))
+	}
+
+	if v, ok := data.GetOk("field_delimiter"); ok {
+		builder.WithFieldDelimiter(v.(string))
+	}
+
+	if v, ok := data.GetOk("file_extension"); ok {
+		builder.WithFileExtension(v.(string))
+	}
+
+	if v, ok := data.GetOk("skip_header"); ok {
+		builder.WithSkipHeader(v.(int))
+	}
+
+	if v, ok := data.GetOk("skip_blank_lines"); ok {
+		builder.WithSkipBlankLines(v.(bool))
+	}
+
+	if v, ok := data.GetOk("date_format"); ok {
+		builder.WithDateFormat(v.(string))
+	}
+
+	if v, ok := data.GetOk("time_format"); ok {
+		builder.WithTimeFormat(v.(string))
+	}
+
+	if v, ok := data.GetOk("timestamp_format"); ok {
+		builder.WithTimestampFormat(v.(string))
+	}
+
+	if v, ok := data.GetOk("binary_format"); ok {
+		builder.WithBinaryFormat(v.(string))
+	}
+
+	if v, ok := data.GetOk("escape"); ok {
+		builder.WithEscape(v.(string))
+	}
+
+	if v, ok := data.GetOk("escape_unenclosed_field"); ok {
+		builder.WithEscapeUnenclosedField(v.(string))
+	}
+
+	if v, ok := data.GetOk("field_optionally_enclosed_by"); ok {
+		builder.WithFieldOptionallyEnclosedBy(v.(string))
+	}
+
+	if v, ok := data.GetOk("error_on_column_count_mismatch"); ok {
+		builder.WithErrorOnColumnCountMismatch(v.(bool))
+	}
+
+	if v, ok := data.GetOk("replace_invalid_characters"); ok {
+		builder.WithReplaceInvalidCharacters(v.(bool))
+	}
+
+	if v, ok := data.GetOk("validate_utf8"); ok {
+		builder.WithValidateUtf8(v.(bool))
+	}
+
+	if v, ok := data.GetOk("empty_field_as_null"); ok {
+		builder.WithEmptyFieldAsNull(v.(bool))
+	}
+
+	if v, ok := data.GetOk("skip_byte_order_mark"); ok {
+		builder.WithSkipByteOrderMark(v.(bool))
+	}
+
+	if v, ok := data.GetOk("encoding"); ok {
+		builder.WithEncoding(v.(string))
+	}
+
 	if err := snowflake.Exec(db, builder.Create()); err != nil {
 		return errors.Wrapf(err, "error creating file format %v", name)
 	}
@@ -270,6 +439,78 @@ func ReadFileFormat(data *schema.ResourceData, metadata interface{}) error {
 		return err
 	}
 
+	if err := data.Set("record_delimiter", ffData.RecordDelimiter); err != nil {
+		return err
+	}
+
+	if err := data.Set("field_delimiter", ffData.FieldDelimiter); err != nil {
+		return err
+	}
+
+	if err := data.Set("file_extension", ffData.FileExtension); err != nil {
+		return err
+	}
+
+	if err := data.Set("skip_header", ffData.SkipHeader); err != nil {
+		return err
+	}
+
+	if err := data.Set("skip_blank_lines", ffData.SkipBlankLines); err != nil {
+		return err
+	}
+
+	if err := data.Set("date_format", ffData.DateFormat); err != nil {
+		return err
+	}
+
+	if err := data.Set("time_format", ffData.TimeFormat); err != nil {
+		return err
+	}
+
+	if err := data.Set("timestamp_format", ffData.TimestampFormat); err != nil {
+		return err
+	}
+
+	if err := data.Set("binary_format", ffData.BinaryFormat); err != nil {
+		return err
+	}
+
+	if err := data.Set("escape", ffData.Escape); err != nil {
+		return err
+	}
+
+	if err := data.Set("escape_unenclosed_field", ffData.EscapeUnenclosedField); err != nil {
+		return err
+	}
+
+	if err := data.Set("field_optionally_enclosed_by", ffData.FieldOptionallyEnclosedBy); err != nil {
+		return err
+	}
+
+	if err := data.Set("error_on_column_count_mismatch", ffData.ErrorOnColumnCountMismatch); err != nil {
+		return err
+	}
+
+	if err := data.Set("replace_invalid_characters", ffData.ReplaceInvalidCharacters); err != nil {
+		return err
+	}
+
+	if err := data.Set("validate_utf8", ffData.ValidateUtf8); err != nil {
+		return err
+	}
+
+	if err := data.Set("empty_field_as_null", ffData.EmptyFieldAsNull); err != nil {
+		return err
+	}
+
+	if err := data.Set("skip_byte_order_mark", ffData.SkipByteOrderMark); err != nil {
+		return err
+	}
+
+	if err := data.Set("encoding", ffData.Encoding); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -341,6 +582,168 @@ func UpdateFileFormat(data *schema.ResourceData, meta interface{}) error {
 		}
 
 		data.SetPartial("null_if")
+	}
+
+	if data.HasChange("record_delimiter") {
+		_, recordDelimiter := data.GetChange("record_delimiter")
+		if err := snowflake.Exec(db, builder.ChangeRecordDelimiter(recordDelimiter.(string))); err != nil {
+			return errors.Wrapf(err, "error updating file format record_delimiter on %v", data.Id())
+		}
+
+		data.SetPartial("record_delimiter")
+	}
+
+	if data.HasChange("field_delimiter") {
+		_, fieldDelimiter := data.GetChange("field_delimiter")
+		if err := snowflake.Exec(db, builder.ChangeFieldDelimiter(fieldDelimiter.(string))); err != nil {
+			return errors.Wrapf(err, "error updating file format field_delimiter on %v", data.Id())
+		}
+
+		data.SetPartial("field_delimiter")
+	}
+
+	if data.HasChange("file_extension") {
+		_, fileExtension := data.GetChange("file_extension")
+		if err := snowflake.Exec(db, builder.ChangeFileExtension(fileExtension.(string))); err != nil {
+			return errors.Wrapf(err, "error updating file format file_extension on %v", data.Id())
+		}
+
+		data.SetPartial("file_extension")
+	}
+
+	if data.HasChange("skip_header") {
+		_, skipHeader := data.GetChange("skip_header")
+		if err := snowflake.Exec(db, builder.ChangeSkipHeader(skipHeader.(int))); err != nil {
+			return errors.Wrapf(err, "error updating file format skip_header on %v", data.Id())
+		}
+
+		data.SetPartial("skip_header")
+	}
+
+	if data.HasChange("skip_blank_lines") {
+		_, skipBlankLines := data.GetChange("skip_blank_lines")
+		if err := snowflake.Exec(db, builder.ChangeSkipBlankLines(skipBlankLines.(bool))); err != nil {
+			return errors.Wrapf(err, "error updating file format skip_blank_lines on %v", data.Id())
+		}
+
+		data.SetPartial("skip_blank_lines")
+	}
+
+	if data.HasChange("date_format") {
+		_, dateFormat := data.GetChange("date_format")
+		if err := snowflake.Exec(db, builder.ChangeDateFormat(dateFormat.(string))); err != nil {
+			return errors.Wrapf(err, "error updating file format date_format on %v", data.Id())
+		}
+
+		data.SetPartial("date_format")
+	}
+
+	if data.HasChange("time_format") {
+		_, timeFormat := data.GetChange("time_format")
+		if err := snowflake.Exec(db, builder.ChangeTimeFormat(timeFormat.(string))); err != nil {
+			return errors.Wrapf(err, "error updating file format time_format on %v", data.Id())
+		}
+
+		data.SetPartial("time_format")
+	}
+
+	if data.HasChange("timestamp_format") {
+		_, timestampFormat := data.GetChange("timestamp_format")
+		if err := snowflake.Exec(db, builder.ChangeTimestampFormat(timestampFormat.(string))); err != nil {
+			return errors.Wrapf(err, "error updating file format timestamp_format on %v", data.Id())
+		}
+
+		data.SetPartial("timestamp_format")
+	}
+
+	if data.HasChange("binary_format") {
+		_, binaryFormat := data.GetChange("binary_format")
+		if err := snowflake.Exec(db, builder.ChangeBinaryFormat(binaryFormat.(string))); err != nil {
+			return errors.Wrapf(err, "error updating file format binary_format on %v", data.Id())
+		}
+
+		data.SetPartial("binary_format")
+	}
+
+	if data.HasChange("escape") {
+		_, escape := data.GetChange("escape")
+		if err := snowflake.Exec(db, builder.ChangeEscape(escape.(string))); err != nil {
+			return errors.Wrapf(err, "error updating file format escape on %v", data.Id())
+		}
+
+		data.SetPartial("escape")
+	}
+
+	if data.HasChange("escape_unenclosed_field") {
+		_, escapeUnenclosedField := data.GetChange("escape_unenclosed_field")
+		if err := snowflake.Exec(db, builder.ChangeEscapeUnenclosedField(escapeUnenclosedField.(string))); err != nil {
+			return errors.Wrapf(err, "error updating file format escape_unenclosed_field on %v", data.Id())
+		}
+
+		data.SetPartial("escape_unenclosed_field")
+	}
+
+	if data.HasChange("field_optionally_enclosed_by") {
+		_, fieldOptionallyEnclosedBy := data.GetChange("field_optionally_enclosed_by")
+		if err := snowflake.Exec(db, builder.ChangeFieldOptionallyEnclosedBy(fieldOptionallyEnclosedBy.(string))); err != nil {
+			return errors.Wrapf(err, "error updating file format field_optionally_enclosed_by on %v", data.Id())
+		}
+
+		data.SetPartial("field_optionally_enclosed_by")
+	}
+
+	if data.HasChange("error_on_column_count_mismatch") {
+		_, errorOnColumnCountMismatch := data.GetChange("error_on_column_count_mismatch")
+		if err := snowflake.Exec(db, builder.ChangeErrorOnColumnCountMismatch(errorOnColumnCountMismatch.(bool))); err != nil {
+			return errors.Wrapf(err, "error updating file format error_on_column_count_mismatch on %v", data.Id())
+		}
+
+		data.SetPartial("error_on_column_count_mismatch")
+	}
+
+	if data.HasChange("replace_invalid_characters") {
+		_, replaceInvalidCharacters := data.GetChange("replace_invalid_characters")
+		if err := snowflake.Exec(db, builder.ChangeReplaceInvalidCharacters(replaceInvalidCharacters.(bool))); err != nil {
+			return errors.Wrapf(err, "error updating file format replace_invalid_characters on %v", data.Id())
+		}
+
+		data.SetPartial("replace_invalid_characters")
+	}
+
+	if data.HasChange("validate_utf8") {
+		_, validateUtf8 := data.GetChange("validate_utf8")
+		if err := snowflake.Exec(db, builder.ChangeValidateUtf8(validateUtf8.(bool))); err != nil {
+			return errors.Wrapf(err, "error updating file format validate_utf8 on %v", data.Id())
+		}
+
+		data.SetPartial("validate_utf8")
+	}
+
+	if data.HasChange("empty_field_as_null") {
+		_, emptyFieldAsNull := data.GetChange("empty_field_as_null")
+		if err := snowflake.Exec(db, builder.ChangeEmptyFieldAsNull(emptyFieldAsNull.(bool))); err != nil {
+			return errors.Wrapf(err, "error updating file format empty_field_as_null on %v", data.Id())
+		}
+
+		data.SetPartial("empty_field_as_null")
+	}
+
+	if data.HasChange("skip_byte_order_mark") {
+		_, skipByteOrderMark := data.GetChange("skip_byte_order_mark")
+		if err := snowflake.Exec(db, builder.ChangeSkipByteOrderMark(skipByteOrderMark.(bool))); err != nil {
+			return errors.Wrapf(err, "error updating file format skip_byte_order_mark on %v", data.Id())
+		}
+
+		data.SetPartial("skip_byte_order_mark")
+	}
+
+	if data.HasChange("encoding") {
+		_, encoding := data.GetChange("encoding")
+		if err := snowflake.Exec(db, builder.ChangeEncoding(encoding.(string))); err != nil {
+			return errors.Wrapf(err, "error updating file format encoding on %v", data.Id())
+		}
+
+		data.SetPartial("encoding")
 	}
 
 	return ReadFileFormat(data, meta)

--- a/pkg/resources/file_format.go
+++ b/pkg/resources/file_format.go
@@ -60,6 +60,7 @@ var fileFormatSchema = map[string]*schema.Schema{
 	"compression": {
 		Type:        schema.TypeString,
 		Optional:    true,
+		Computed:    true,
 		Description: "Specifies the current compression algorithm for columns in the Parquet files.",
 		ValidateFunc: func(val interface{}, _ string) ([]string, []error) {
 			c := strings.ToLower(val.(string))
@@ -75,62 +76,74 @@ var fileFormatSchema = map[string]*schema.Schema{
 	"binary_as_text": {
 		Type:        schema.TypeBool,
 		Optional:    true,
+		Computed:    true,
 		Description: "Boolean that specifies whether to interpret columns with no defined logical data type as UTF-8 text. When set to FALSE, Snowflake interprets these columns as binary data.",
 	},
 	"trim_space": {
 		Type:        schema.TypeBool,
 		Optional:    true,
+		Computed:    true,
 		Description: "Applied only when loading Parquet data into separate columns (i.e. using the MATCH_BY_COLUMN_NAME copy option or a COPY transformation). Boolean that specifies whether to remove leading and trailing white space from strings.",
 	},
 	"null_if": {
 		Type:        schema.TypeList,
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Optional:    true,
+		Computed:    true,
 		Description: "Applied only when loading Parquet data into separate columns (i.e. using the MATCH_BY_COLUMN_NAME copy option or a COPY transformation). String used to convert to and from SQL NULL. Snowflake replaces these strings in the data load source with SQL NULL.",
 	},
 	"record_delimiter": {
 		Type:        schema.TypeString,
 		Optional:    true,
+		Computed:    true,
 		Description: "One or more singlebyte or multibyte characters that separate records in an input file (data loading) or unloaded file (data unloading).",
 	},
 	"field_delimiter": {
 		Type:        schema.TypeString,
 		Optional:    true,
+		Computed:    true,
 		Description: "One or more singlebyte or multibyte characters that separate fields in an input file (data loading) or unloaded file (data unloading).",
 	},
 	"file_extension": {
 		Type:        schema.TypeString,
 		Optional:    true,
+		Computed:    true,
 		Description: "Specifies the extension for files unloaded to a stage.",
 	},
 	"skip_header": {
 		Type:        schema.TypeInt,
 		Optional:    true,
+		Computed:    true,
 		Description: "Number of lines at the start of the file to skip.",
 	},
 	"skip_blank_lines": {
 		Type:        schema.TypeBool,
 		Optional:    true,
+		Computed:    true,
 		Description: "Boolean that specifies to skip any blank lines encountered in the data files.",
 	},
 	"date_format": {
 		Type:        schema.TypeString,
 		Optional:    true,
+		Computed:    true,
 		Description: "Defines the format of date values in the data files (data loading) or table (data unloading).",
 	},
 	"time_format": {
 		Type:        schema.TypeString,
 		Optional:    true,
+		Computed:    true,
 		Description: "Defines the format of time values in the data files (data loading) or table (data unloading).",
 	},
 	"timestamp_format": {
 		Type:        schema.TypeString,
 		Optional:    true,
+		Computed:    true,
 		Description: "Defines the format of timestamp values in the data files (data loading) or table (data unloading).",
 	},
 	"binary_format": {
 		Type:        schema.TypeString,
 		Optional:    true,
+		Computed:    true,
 		Description: "Defines the encoding format for binary input or output.",
 		ValidateFunc: func(val interface{}, _ string) ([]string, []error) {
 			c := strings.ToLower(val.(string))
@@ -146,46 +159,55 @@ var fileFormatSchema = map[string]*schema.Schema{
 	"escape": {
 		Type:        schema.TypeString,
 		Optional:    true,
+		Computed:    true,
 		Description: "Single character string used as the escape character for field values.",
 	},
 	"escape_unenclosed_field": {
 		Type:        schema.TypeString,
 		Optional:    true,
+		Computed:    true,
 		Description: "Single character string used as the escape character for unenclosed field values only.",
 	},
 	"field_optionally_enclosed_by": {
 		Type:        schema.TypeString,
 		Optional:    true,
+		Computed:    true,
 		Description: "Character used to enclose strings.",
 	},
 	"error_on_column_count_mismatch": {
 		Type:        schema.TypeBool,
 		Optional:    true,
+		Computed:    true,
 		Description: "Boolean that specifies whether to generate a parsing error if the number of delimited columns (i.e. fields) in an input file does not match the number of columns in the corresponding table.",
 	},
 	"replace_invalid_characters": {
 		Type:        schema.TypeBool,
 		Optional:    true,
+		Computed:    true,
 		Description: "Boolean that specifies whether to replace invalid UTF-8 characters with the Unicode replacement character.",
 	},
 	"validate_utf8": {
 		Type:        schema.TypeBool,
 		Optional:    true,
+		Computed:    true,
 		Description: "Boolean that specifies whether to validate UTF-8 character encoding in string column data.",
 	},
 	"empty_field_as_null": {
 		Type:        schema.TypeBool,
 		Optional:    true,
+		Computed:    true,
 		Description: "When loading data, specifies whether to insert SQL NULL for empty fields in an input file, which are represented by two successive delimiters (e.g. ,,). When unloading data, this option is used in combination with FIELD_OPTIONALLY_ENCLOSED_BY. When FIELD_OPTIONALLY_ENCLOSED_BY = NONE, setting EMPTY_FIELD_AS_NULL = FALSE specifies to unload empty strings in tables to empty string values without quotes enclosing the field values. If set to TRUE, FIELD_OPTIONALLY_ENCLOSED_BY must specify a character to enclose strings.",
 	},
 	"skip_byte_order_mark": {
 		Type:        schema.TypeBool,
 		Optional:    true,
+		Computed:    true,
 		Description: "Boolean that specifies whether to skip the BOM (byte order mark), if present in a data file.",
 	},
 	"encoding": {
 		Type:        schema.TypeString,
 		Optional:    true,
+		Computed:    true,
 		Description: "String (constant) that specifies the character set of the source data when loading data into a table.",
 	},
 }

--- a/pkg/resources/file_format_test.go
+++ b/pkg/resources/file_format_test.go
@@ -65,7 +65,7 @@ func TestFileFormatCreate(t *testing.T) {
 	testhelpers.WithMockDb(t, func(db *sql.DB, mock sqlmock.Sqlmock) {
 		mock.ExpectExec(
 			fmt.Sprintf(
-				`^CREATE FILE FORMAT "%v"."%v"."%v" TYPE = "%v" COMMENT = "%v" BINARY_AS_TEXT = true TRIM_SPACE = false$`,
+				`^CREATE FILE FORMAT "%v"."%v"."%v" TYPE = "%v" COMMENT = "%v"$`,
 				databaseName, schemaName, fileFormatName, fileFormatType, comment,
 			),
 		).WillReturnResult(sqlmock.NewResult(1, 1))

--- a/pkg/snowflake/file_format.go
+++ b/pkg/snowflake/file_format.go
@@ -11,15 +11,42 @@ import (
 
 // FileFormatBuilder abstracts the creation of SQL queries for a Snowflake file format
 type FileFormatBuilder struct {
-	name           string
-	db             string
-	schema         string
-	fileFormatType string
-	comment        string
-	compression    string
-	binaryAsText   bool
-	trimSpace      bool
-	nullIf         []string
+	name                          string
+	db                            string
+	schema                        string
+	fileFormatType                string
+	comment                       string
+	compression                   string
+	setBinaryAsText               bool
+	binaryAsText                  bool
+	setTrimSpace                  bool
+	trimSpace                     bool
+	nullIf                        []string
+	recordDelimiter               string
+	fieldDelimiter                string
+	fileExtension                 string
+	setSkipHeader                 bool
+	skipHeader                    int
+	setSkipBlankLines             bool
+	skipBlankLines                bool
+	dateFormat                    string
+	timeFormat                    string
+	timestampFormat               string
+	binaryFormat                  string
+	escape                        string
+	escapeUnenclosedField         string
+	fieldOptionallyEnclosedBy     string
+	setErrorOnColumnCountMismatch bool
+	errorOnColumnCountMismatch    bool
+	setReplaceInvalidCharacters   bool
+	replaceInvalidCharacters      bool
+	setValidateUtf8               bool
+	validateUtf8                  bool
+	setEmptyFieldAsNull           bool
+	emptyFieldAsNull              bool
+	setSkipByteOrderMark          bool
+	skipByteOrderMark             bool
+	encoding                      string
 }
 
 // QualifiedName prepends the db and schema and escapes everything nicely
@@ -51,12 +78,14 @@ func (fb *FileFormatBuilder) WithCompression(compression string) *FileFormatBuil
 
 // WithBinaryAsText adds binary as text to the FileFormatBuilder
 func (fb *FileFormatBuilder) WithBinaryAsText(binaryAsText bool) *FileFormatBuilder {
+	fb.setBinaryAsText = true
 	fb.binaryAsText = binaryAsText
 	return fb
 }
 
 // WithTrimSpace adds trim space to the FileFormatBuilder
 func (fb *FileFormatBuilder) WithTrimSpace(trimSpace bool) *FileFormatBuilder {
+	fb.setTrimSpace = true
 	fb.trimSpace = trimSpace
 	return fb
 }
@@ -67,10 +96,129 @@ func (fb *FileFormatBuilder) WithNullIf(nullIf []string) *FileFormatBuilder {
 	return fb
 }
 
+// WithRecordDelimiter adds a record delimiter to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithRecordDelimiter(recordDelimiter string) *FileFormatBuilder {
+	fb.recordDelimiter = recordDelimiter
+	return fb
+}
+
+// WithFieldDelimiter adds a field delimiter to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithFieldDelimiter(fieldDelimiter string) *FileFormatBuilder {
+	fb.fieldDelimiter = fieldDelimiter
+	return fb
+}
+
+// WithFileExtension adds a file extension to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithFileExtension(fileExtension string) *FileFormatBuilder {
+	fb.fileExtension = fileExtension
+	return fb
+}
+
+// WithSkipHeader adds skip header to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithSkipHeader(skipHeader int) *FileFormatBuilder {
+	fb.setSkipHeader = true
+	fb.skipHeader = skipHeader
+	return fb
+}
+
+// WithSkipBlankLines adds skip blank lines to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithSkipBlankLines(skipBlankLines bool) *FileFormatBuilder {
+	fb.setSkipBlankLines = true
+	fb.skipBlankLines = skipBlankLines
+	return fb
+}
+
+// WithDateFormat adds a date format to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithDateFormat(dateFormat string) *FileFormatBuilder {
+	fb.dateFormat = dateFormat
+	return fb
+}
+
+// WithTimeFormat adds a time format to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithTimeFormat(timeFormat string) *FileFormatBuilder {
+	fb.timeFormat = timeFormat
+	return fb
+}
+
+// WithTimestampFormat adds a timestamp format to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithTimestampFormat(timestampFormat string) *FileFormatBuilder {
+	fb.timestampFormat = timestampFormat
+	return fb
+}
+
+// WithBinaryFormat adds a binary format to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithBinaryFormat(binaryFormat string) *FileFormatBuilder {
+	fb.binaryFormat = binaryFormat
+	return fb
+}
+
+// WithEscape adds escape to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithEscape(escape string) *FileFormatBuilder {
+	fb.escape = escape
+	return fb
+}
+
+// WithEscapeUnenclosedField adds escape unenclosed field to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithEscapeUnenclosedField(escapeUnenclosedField string) *FileFormatBuilder {
+	fb.escapeUnenclosedField = escapeUnenclosedField
+	return fb
+}
+
+// WithFieldOptionallyEnclosedBy adds field optionally enclosed by to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithFieldOptionallyEnclosedBy(fieldOptionallyEnclosedBy string) *FileFormatBuilder {
+	fb.fieldOptionallyEnclosedBy = fieldOptionallyEnclosedBy
+	return fb
+}
+
+// WithErrorOnColumnCountMismatch adds error on column counter mismatch to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithErrorOnColumnCountMismatch(errorOnColumnCountMismatch bool) *FileFormatBuilder {
+	fb.setErrorOnColumnCountMismatch = true
+	fb.errorOnColumnCountMismatch = errorOnColumnCountMismatch
+	return fb
+}
+
+// WithReplaceInvalidCharacters adds replace invalid characters to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithReplaceInvalidCharacters(replaceInvalidCharacters bool) *FileFormatBuilder {
+	fb.setReplaceInvalidCharacters = true
+	fb.replaceInvalidCharacters = replaceInvalidCharacters
+	return fb
+}
+
+// WithValidateUtf8 adds validate UTF8 to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithValidateUtf8(validateUtf8 bool) *FileFormatBuilder {
+	fb.setValidateUtf8 = true
+	fb.validateUtf8 = validateUtf8
+	return fb
+}
+
+// WithEmptyFieldAsNull adds empty field as null to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithEmptyFieldAsNull(emptyFieldAsNull bool) *FileFormatBuilder {
+	fb.setEmptyFieldAsNull = true
+	fb.emptyFieldAsNull = emptyFieldAsNull
+	return fb
+}
+
+// WithSkipByteOrderMark adds skip byte order mark to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithSkipByteOrderMark(skipByteOrderMark bool) *FileFormatBuilder {
+	fb.setSkipByteOrderMark = true
+	fb.skipByteOrderMark = skipByteOrderMark
+	return fb
+}
+
+// WithEncoding adds encoding to the FileFormatBuilder
+func (fb *FileFormatBuilder) WithEncoding(encoding string) *FileFormatBuilder {
+	fb.encoding = encoding
+	return fb
+}
+
 // FileFormat returns a pointer to a Builder that abstracts the DDL operations for a stage.
 //
 // Supported DDL operations are:
+//   - CREATE FILE FORMAT
+//   - ALTER FILE FORMAT
+//   - DROP FILE FORMAT
 //   - DESCRIBE FILE FORMAT
+//   - SHOW FILE FORMAT
 //
 // [Snowflake Reference](https://docs.snowflake.com/en/sql-reference/ddl-stage.html#file-format-management)
 func FileFormat(name, db, schema string) *FileFormatBuilder {
@@ -87,10 +235,6 @@ func (fb *FileFormatBuilder) Create() string {
 	builder.WriteString(`CREATE FILE FORMAT `)
 	builder.WriteString(fb.QualifiedName())
 
-	builder.WriteString(fmt.Sprintf(` BINARY_AS_TEXT = %v`, fb.binaryAsText))
-
-	builder.WriteString(fmt.Sprintf(` TRIM_SPACE = %v`, fb.trimSpace))
-
 	if fb.fileFormatType != "" {
 		builder.WriteString(fmt.Sprintf(` TYPE = "%v"`, fb.fileFormatType))
 	}
@@ -103,6 +247,14 @@ func (fb *FileFormatBuilder) Create() string {
 		builder.WriteString(fmt.Sprintf(` COMPRESSION = "%v"`, fb.compression))
 	}
 
+	if fb.setBinaryAsText {
+		builder.WriteString(fmt.Sprintf(` BINARY_AS_TEXT = %v`, fb.binaryAsText))
+	}
+
+	if fb.setTrimSpace {
+		builder.WriteString(fmt.Sprintf(` TRIM_SPACE = %v`, fb.trimSpace))
+	}
+
 	if len(fb.nullIf) > 0 {
 		nulls := make([]string, len(fb.nullIf))
 		for i, n := range fb.nullIf {
@@ -111,12 +263,84 @@ func (fb *FileFormatBuilder) Create() string {
 		builder.WriteString(fmt.Sprintf(` NULL_IF = (%v)`, strings.Join(nulls, ",")))
 	}
 
+	if fb.recordDelimiter != "" {
+		builder.WriteString(fmt.Sprintf(` RECORD_DELIMITER = "%v"`, EscapeString(fb.recordDelimiter)))
+	}
+
+	if fb.fieldDelimiter != "" {
+		builder.WriteString(fmt.Sprintf(` FIELD_DELIMITER = "%v"`, EscapeString(fb.fieldDelimiter)))
+	}
+
+	if fb.fileExtension != "" {
+		builder.WriteString(fmt.Sprintf(` FILE_EXTENSION = "%v"`, EscapeString(fb.fileExtension)))
+	}
+
+	if fb.setSkipHeader {
+		builder.WriteString(fmt.Sprintf(` SKIP_HEADER = %v`, fb.skipHeader))
+	}
+
+	if fb.setSkipBlankLines {
+		builder.WriteString(fmt.Sprintf(` SKIP_BLANK_LINES = %v`, fb.skipBlankLines))
+	}
+
+	if fb.dateFormat != "" {
+		builder.WriteString(fmt.Sprintf(` DATE_FORMAT = "%v"`, EscapeString(fb.dateFormat)))
+	}
+
+	if fb.timeFormat != "" {
+		builder.WriteString(fmt.Sprintf(` TIME_FORMAT = "%v"`, EscapeString(fb.timeFormat)))
+	}
+
+	if fb.timestampFormat != "" {
+		builder.WriteString(fmt.Sprintf(` TIMESTAMP_FORMAT = "%v"`, EscapeString(fb.timestampFormat)))
+	}
+
+	if fb.binaryFormat != "" {
+		builder.WriteString(fmt.Sprintf(` BINARY_FORMAT = %v`, fb.binaryFormat))
+	}
+
+	if fb.escape != "" {
+		builder.WriteString(fmt.Sprintf(` ESCAPE = "%v"`, EscapeString(fb.escape)))
+	}
+
+	if fb.escapeUnenclosedField != "" {
+		builder.WriteString(fmt.Sprintf(` ESCAPE_UNENCLOSED_FIELD = "%v"`, EscapeString(fb.escapeUnenclosedField)))
+	}
+
+	if fb.fieldOptionallyEnclosedBy != "" {
+		builder.WriteString(fmt.Sprintf(` FIELD_OPTIONALLY_ENCLOSED_BY = "%v"`, EscapeString(fb.fieldOptionallyEnclosedBy)))
+	}
+
+	if fb.setErrorOnColumnCountMismatch {
+		builder.WriteString(fmt.Sprintf(` ERROR_ON_COLUMN_COUNT_MISMATCH = %v`, fb.errorOnColumnCountMismatch))
+	}
+
+	if fb.setReplaceInvalidCharacters {
+		builder.WriteString(fmt.Sprintf(` REPLACE_INVALID_CHARACTERS = %v`, fb.replaceInvalidCharacters))
+	}
+
+	if fb.setValidateUtf8 {
+		builder.WriteString(fmt.Sprintf(` VALIDATE_UTF8 = %v`, fb.validateUtf8))
+	}
+
+	if fb.setEmptyFieldAsNull {
+		builder.WriteString(fmt.Sprintf(` EMPTY_FIELD_AS_NULL = %v`, fb.emptyFieldAsNull))
+	}
+
+	if fb.setSkipByteOrderMark {
+		builder.WriteString(fmt.Sprintf(` SKIP_BYTE_ORDER_MARK = %v`, fb.skipByteOrderMark))
+	}
+
+	if fb.encoding != "" {
+		builder.WriteString(fmt.Sprintf(` ENCODING = "%v"`, EscapeString(fb.encoding)))
+	}
+
 	return builder.String()
 }
 
 // ChangeComment returns the SQL query that will update the comment on the file format.
 func (fb *FileFormatBuilder) ChangeComment(comment string) string {
-	return fmt.Sprintf(`ALTER FILE FORMAT %v SET COMMENT = "%v"`, fb.QualifiedName(), comment)
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET COMMENT = "%v"`, fb.QualifiedName(), EscapeString(comment))
 }
 
 // ChangeComment returns the SQL query that will update the compression on the file format.
@@ -141,6 +365,96 @@ func (fb *FileFormatBuilder) ChangeNullIf(nullIf []string) string {
 		nulls[i] = fmt.Sprintf(`'%v'`, EscapeString(n))
 	}
 	return fmt.Sprintf(`ALTER FILE FORMAT %v SET NULL_IF = (%v)`, fb.QualifiedName(), strings.Join(nulls, ","))
+}
+
+// ChangeRecordDelimiter returns the SQL query that will update record delimiter on the file format.
+func (fb *FileFormatBuilder) ChangeRecordDelimiter(recordDelimiter string) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET RECORD_DELIMITER = "%v"`, fb.QualifiedName(), EscapeString(recordDelimiter))
+}
+
+// ChangeFieldDelimiter returns the SQL query that will update field delimiter on the file format.
+func (fb *FileFormatBuilder) ChangeFieldDelimiter(fieldDelimiter string) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET FIELD_DELIMITER = "%v"`, fb.QualifiedName(), EscapeString(fieldDelimiter))
+}
+
+// ChangeFileExtension returns the SQL query that will update file extension on the file format.
+func (fb *FileFormatBuilder) ChangeFileExtension(fileExtension string) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET FILE_EXTENSION = "%v"`, fb.QualifiedName(), EscapeString(fileExtension))
+}
+
+// ChangeSkipHeader returns the SQL query that will update skip header on the file format.
+func (fb *FileFormatBuilder) ChangeSkipHeader(skipHeader int) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET SKIP_HEADER = %v`, fb.QualifiedName(), skipHeader)
+}
+
+// ChangeSkipBlankLines returns the SQL query that will update skip blank lines on the file format.
+func (fb *FileFormatBuilder) ChangeSkipBlankLines(skipBlankLines bool) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET SKIP_BLANK_LINES = %v`, fb.QualifiedName(), skipBlankLines)
+}
+
+// ChangeDateFormat returns the SQL query that will update dateformat on the file format.
+func (fb *FileFormatBuilder) ChangeDateFormat(dateFormat string) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET DATE_FORMAT = "%v"`, fb.QualifiedName(), EscapeString(dateFormat))
+}
+
+// ChangeTimeFormat returns the SQL query that will update time format on the file format.
+func (fb *FileFormatBuilder) ChangeTimeFormat(timeFormat string) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET TIME_FORMAT = "%v"`, fb.QualifiedName(), EscapeString(timeFormat))
+}
+
+// ChangeTimestampFormat returns the SQL query that will update timestamp format on the file format.
+func (fb *FileFormatBuilder) ChangeTimestampFormat(timestampFormat string) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET TIMESTAMP_FORMAT = "%v"`, fb.QualifiedName(), EscapeString(timestampFormat))
+}
+
+// ChangeBinaryFormat returns the SQL query that will update binary format on the file format.
+func (fb *FileFormatBuilder) ChangeBinaryFormat(binaryFormat string) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET BINARY_FORMAT = %v`, fb.QualifiedName(), binaryFormat)
+}
+
+// ChangeEscape returns the SQL query that will update escape on the file format.
+func (fb *FileFormatBuilder) ChangeEscape(escape string) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET ESCAPE = "%v"`, fb.QualifiedName(), EscapeString(escape))
+}
+
+// ChangeEscapeUnenclosedField returns the SQL query that will update escape unenclosed field on the file format.
+func (fb *FileFormatBuilder) ChangeEscapeUnenclosedField(escapeUnenclosedField string) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET ESCAPE_UNENCLOSED_FIELD = "%v"`, fb.QualifiedName(), EscapeString(escapeUnenclosedField))
+}
+
+// ChangeFieldOptionallyEnclosedBy returns the SQL query that will update field optionally enclosed by on the file format.
+func (fb *FileFormatBuilder) ChangeFieldOptionallyEnclosedBy(fieldOptionallyEnclosedBy string) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET FIELD_OPTIONALLY_ENCLOSED_BY = "%v"`, fb.QualifiedName(), EscapeString(fieldOptionallyEnclosedBy))
+}
+
+// ChangeErrorOnColumnCountMismatch returns the SQL query that will update error on column count mismatch on the file format.
+func (fb *FileFormatBuilder) ChangeErrorOnColumnCountMismatch(errorOnColumnCountMismatch bool) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET ERROR_ON_COLUMN_COUNT_MISMATCH = %v`, fb.QualifiedName(), errorOnColumnCountMismatch)
+}
+
+// ChangeReplaceInvalidCharacters returns the SQL query that will update replace invalid characters on the file format.
+func (fb *FileFormatBuilder) ChangeReplaceInvalidCharacters(replaceInvalidCharacters bool) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET REPLACE_INVALID_CHARACTERS = %v`, fb.QualifiedName(), replaceInvalidCharacters)
+}
+
+// ChangeValidateUtf8 returns the SQL query that will update validate utf8 on the file format.
+func (fb *FileFormatBuilder) ChangeValidateUtf8(validateUtf8 bool) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET VALIDATE_UTF8 = %v`, fb.QualifiedName(), validateUtf8)
+}
+
+// ChangeEmptyFieldAsNull returns the SQL query that will update empty field as null on the file format.
+func (fb *FileFormatBuilder) ChangeEmptyFieldAsNull(emptyFieldAsNull bool) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET EMPTY_FIELD_AS_NULL = %v`, fb.QualifiedName(), emptyFieldAsNull)
+}
+
+// ChangeSkipByteOrderMark returns the SQL query that will update skip byte order mark on the file format.
+func (fb *FileFormatBuilder) ChangeSkipByteOrderMark(skipByteOrderMark bool) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET SKIP_BYTE_ORDER_MARK = %v`, fb.QualifiedName(), skipByteOrderMark)
+}
+
+// ChangeEncoding returns the SQL query that will update encoding on the file format.
+func (fb *FileFormatBuilder) ChangeEncoding(encoding string) string {
+	return fmt.Sprintf(`ALTER FILE FORMAT %v SET ENCODING = "%v"`, fb.QualifiedName(), EscapeString(encoding))
 }
 
 // Drop returns the SQL query that will drop a file format.
@@ -173,11 +487,29 @@ func ScanFileFormatShow(row *sqlx.Row) (*fileFormatMetadata, error) {
 }
 
 type fileFormatData struct {
-	Type         string
-	Compression  string
-	BinaryAsText bool
-	TrimSpace    bool
-	NullIf       []string
+	Type                       string
+	Compression                string
+	BinaryAsText               bool
+	TrimSpace                  bool
+	NullIf                     []string
+	RecordDelimiter            string
+	FieldDelimiter             string
+	FileExtension              string
+	SkipHeader                 int
+	SkipBlankLines             bool
+	DateFormat                 string
+	TimeFormat                 string
+	TimestampFormat            string
+	BinaryFormat               string
+	Escape                     string
+	EscapeUnenclosedField      string
+	FieldOptionallyEnclosedBy  string
+	ErrorOnColumnCountMismatch bool
+	ReplaceInvalidCharacters   bool
+	ValidateUtf8               bool
+	EmptyFieldAsNull           bool
+	SkipByteOrderMark          bool
+	Encoding                   string
 }
 
 type descFileFormatRow struct {
@@ -230,6 +562,70 @@ func DescFileFormat(db *sql.DB, query string) (*fileFormatData, error) {
 					result.NullIf[i] = UnescapeString(strings.TrimSpace(str))
 				}
 			}
+		case "RECORD_DELIMITER":
+			result.RecordDelimiter = row.PropertyValue
+		case "FIELD_DELIMITER":
+			result.FieldDelimiter = row.PropertyValue
+		case "FILE_EXTENSION":
+			result.FileExtension = row.PropertyValue
+		case "SKIP_HEADER":
+			v, err := strconv.Atoi(row.PropertyValue)
+			if err != nil {
+				return &fileFormatData{}, err
+			}
+			result.SkipHeader = v
+		case "SKIP_BLANK_LINES":
+			v, err := strconv.ParseBool(row.PropertyValue)
+			if err != nil {
+				return &fileFormatData{}, err
+			}
+			result.SkipBlankLines = v
+		case "DATE_FORMAT":
+			result.DateFormat = row.PropertyValue
+		case "TIME_FORMAT":
+			result.TimeFormat = row.PropertyValue
+		case "TIMESTAMP_FORMAT":
+			result.TimestampFormat = row.PropertyValue
+		case "BINARY_FORMAT":
+			result.BinaryFormat = row.PropertyValue
+		case "ESCAPE":
+			result.Escape = row.PropertyValue
+		case "ESCAPE_UNENCLOSED_FIELD":
+			result.EscapeUnenclosedField = row.PropertyValue
+		case "FIELD_OPTIONALLY_ENCLOSED_BY":
+			result.FieldOptionallyEnclosedBy = row.PropertyValue
+		case "ERROR_ON_COLUMN_COUNT_MISMATCH":
+			v, err := strconv.ParseBool(row.PropertyValue)
+			if err != nil {
+				return &fileFormatData{}, err
+			}
+			result.ErrorOnColumnCountMismatch = v
+		case "REPLACE_INVALID_CHARACTERS":
+			v, err := strconv.ParseBool(row.PropertyValue)
+			if err != nil {
+				return &fileFormatData{}, err
+			}
+			result.ReplaceInvalidCharacters = v
+		case "VALIDATE_UTF8":
+			v, err := strconv.ParseBool(row.PropertyValue)
+			if err != nil {
+				return &fileFormatData{}, err
+			}
+			result.ValidateUtf8 = v
+		case "EMPTY_FIELD_AS_NULL":
+			v, err := strconv.ParseBool(row.PropertyValue)
+			if err != nil {
+				return &fileFormatData{}, err
+			}
+			result.EmptyFieldAsNull = v
+		case "SKIP_BYTE_ORDER_MARK":
+			v, err := strconv.ParseBool(row.PropertyValue)
+			if err != nil {
+				return &fileFormatData{}, err
+			}
+			result.SkipByteOrderMark = v
+		case "ENCODING":
+			result.Encoding = row.PropertyValue
 		}
 	}
 

--- a/pkg/snowflake/file_format_test.go
+++ b/pkg/snowflake/file_format_test.go
@@ -10,14 +10,32 @@ import (
 )
 
 const (
-	fileFormatName = "test_file_format"
-	databaseName   = "test_db"
-	schemaName     = "test_schema"
-	binaryAsText   = true
-	trimSpace      = true
-	fileFormatType = "parquet"
-	comment        = "This is a test"
-	compression    = "lzo"
+	fileFormatName             = "test_file_format"
+	databaseName               = "test_db"
+	schemaName                 = "test_schema"
+	fileFormatType             = "parquet"
+	comment                    = "This is a test"
+	compression                = "lzo"
+	binaryAsText               = true
+	trimSpace                  = false
+	recordDelimiter            = `\n`
+	fieldDelimiter             = "."
+	fileExtension              = ".csv.lzo"
+	skipHeader                 = 1
+	skipBlankLines             = false
+	dateFormat                 = "auto"
+	timeFormat                 = "auto"
+	timestampFormat            = "auto"
+	binaryFormat               = "HEX"
+	escape                     = "none"
+	escapeUnenclosedField      = `\`
+	fieldOptionallyEnclosedBy  = "none"
+	errorOnColumnCountMismatch = true
+	replaceInvalidCharacters   = false
+	validateUtf8               = true
+	emptyFieldAsNull           = true
+	skipByteOrderMark          = true
+	encoding                   = "UTF8"
 )
 
 func TestFileFormatCreate(t *testing.T) {
@@ -27,22 +45,8 @@ func TestFileFormatCreate(t *testing.T) {
 	r.Equal(fmt.Sprintf(`"%v"."%v"."%v"`, databaseName, schemaName, fileFormatName), ff.QualifiedName())
 
 	query := fmt.Sprintf(
-		`CREATE FILE FORMAT "%v"."%v"."%v" BINARY_AS_TEXT = false TRIM_SPACE = false`,
+		`CREATE FILE FORMAT "%v"."%v"."%v"`,
 		databaseName, schemaName, fileFormatName,
-	)
-	r.Equal(query, ff.Create())
-
-	ff.WithBinaryAsText(binaryAsText)
-	query = fmt.Sprintf(
-		`CREATE FILE FORMAT "%v"."%v"."%v" BINARY_AS_TEXT = %v TRIM_SPACE = false`,
-		databaseName, schemaName, fileFormatName, binaryAsText,
-	)
-	r.Equal(query, ff.Create())
-
-	ff.WithTrimSpace(trimSpace)
-	query = fmt.Sprintf(
-		`CREATE FILE FORMAT "%v"."%v"."%v" BINARY_AS_TEXT = %v TRIM_SPACE = %v`,
-		databaseName, schemaName, fileFormatName, binaryAsText, trimSpace,
 	)
 	r.Equal(query, ff.Create())
 
@@ -51,23 +55,104 @@ func TestFileFormatCreate(t *testing.T) {
 	r.Equal(query, ff.Create())
 
 	ff.WithComment(comment)
-	query += fmt.Sprintf(` COMMENT = "%v"`, comment)
+	query += fmt.Sprintf(` COMMENT = "%v"`, snowflake.EscapeString(comment))
 	r.Equal(query, ff.Create())
 
 	ff.WithCompression(compression)
 	query += fmt.Sprintf(` COMPRESSION = "%v"`, compression)
 	r.Equal(query, ff.Create())
 
+	ff.WithBinaryAsText(binaryAsText)
+	query += fmt.Sprintf(` BINARY_AS_TEXT = %v`, binaryAsText)
+	r.Equal(query, ff.Create())
+
+	ff.WithTrimSpace(trimSpace)
+	query += fmt.Sprintf(` TRIM_SPACE = %v`, trimSpace)
+	r.Equal(query, ff.Create())
+
 	ff.WithNullIf([]string{`\N`, "NULL", ""})
 	query += fmt.Sprintf(` NULL_IF = ('\\N','NULL','')`)
 	r.Equal(query, ff.Create())
+
+	ff.WithRecordDelimiter(recordDelimiter)
+	query += fmt.Sprintf(` RECORD_DELIMITER = "%v"`, snowflake.EscapeString(recordDelimiter))
+	r.Equal(query, ff.Create())
+
+	ff.WithFieldDelimiter(fieldDelimiter)
+	query += fmt.Sprintf(` FIELD_DELIMITER = "%v"`, snowflake.EscapeString(fieldDelimiter))
+	r.Equal(query, ff.Create())
+
+	ff.WithFileExtension(fileExtension)
+	query += fmt.Sprintf(` FILE_EXTENSION = "%v"`, snowflake.EscapeString(fileExtension))
+	r.Equal(query, ff.Create())
+
+	ff.WithSkipHeader(skipHeader)
+	query += fmt.Sprintf(` SKIP_HEADER = %v`, skipHeader)
+	r.Equal(query, ff.Create())
+
+	ff.WithSkipBlankLines(skipBlankLines)
+	query += fmt.Sprintf(` SKIP_BLANK_LINES = %v`, skipBlankLines)
+	r.Equal(query, ff.Create())
+
+	ff.WithDateFormat(dateFormat)
+	query += fmt.Sprintf(` DATE_FORMAT = "%v"`, snowflake.EscapeString(dateFormat))
+	r.Equal(query, ff.Create())
+
+	ff.WithTimeFormat(timeFormat)
+	query += fmt.Sprintf(` TIME_FORMAT = "%v"`, snowflake.EscapeString(timeFormat))
+	r.Equal(query, ff.Create())
+
+	ff.WithTimestampFormat(timestampFormat)
+	query += fmt.Sprintf(` TIMESTAMP_FORMAT = "%v"`, snowflake.EscapeString(timestampFormat))
+	r.Equal(query, ff.Create())
+
+	ff.WithBinaryFormat(binaryFormat)
+	query += fmt.Sprintf(` BINARY_FORMAT = %v`, binaryFormat)
+	r.Equal(query, ff.Create())
+
+	ff.WithEscape(escape)
+	query += fmt.Sprintf(` ESCAPE = "%v"`, snowflake.EscapeString(escape))
+	r.Equal(query, ff.Create())
+
+	ff.WithEscapeUnenclosedField(escapeUnenclosedField)
+	query += fmt.Sprintf(` ESCAPE_UNENCLOSED_FIELD = "%v"`, snowflake.EscapeString(escapeUnenclosedField))
+	r.Equal(query, ff.Create())
+
+	ff.WithFieldOptionallyEnclosedBy(fieldOptionallyEnclosedBy)
+	query += fmt.Sprintf(` FIELD_OPTIONALLY_ENCLOSED_BY = "%v"`, snowflake.EscapeString(fieldOptionallyEnclosedBy))
+	r.Equal(query, ff.Create())
+
+	ff.WithErrorOnColumnCountMismatch(errorOnColumnCountMismatch)
+	query += fmt.Sprintf(` ERROR_ON_COLUMN_COUNT_MISMATCH = %v`, errorOnColumnCountMismatch)
+	r.Equal(query, ff.Create())
+
+	ff.WithReplaceInvalidCharacters(replaceInvalidCharacters)
+	query += fmt.Sprintf(` REPLACE_INVALID_CHARACTERS = %v`, replaceInvalidCharacters)
+	r.Equal(query, ff.Create())
+
+	ff.WithValidateUtf8(validateUtf8)
+	query += fmt.Sprintf(` VALIDATE_UTF8 = %v`, validateUtf8)
+	r.Equal(query, ff.Create())
+
+	ff.WithEmptyFieldAsNull(emptyFieldAsNull)
+	query += fmt.Sprintf(` EMPTY_FIELD_AS_NULL = %v`, emptyFieldAsNull)
+	r.Equal(query, ff.Create())
+
+	ff.WithSkipByteOrderMark(skipByteOrderMark)
+	query += fmt.Sprintf(` SKIP_BYTE_ORDER_MARK = %v`, skipByteOrderMark)
+	r.Equal(query, ff.Create())
+
+	ff.WithEncoding(encoding)
+	query += fmt.Sprintf(` ENCODING = "%v"`, snowflake.EscapeString(encoding))
+	r.Equal(query, ff.Create())
+
 }
 
 func TestFileFormatChangeComment(t *testing.T) {
 	r := require.New(t)
 	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
 	r.Equal(
-		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET COMMENT = "%v"`, databaseName, schemaName, fileFormatName, comment),
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET COMMENT = "%v"`, databaseName, schemaName, fileFormatName, snowflake.EscapeString(comment)),
 		ff.ChangeComment(comment),
 	)
 }
@@ -105,6 +190,168 @@ func TestFileFormatChangeNullIf(t *testing.T) {
 	r.Equal(
 		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET NULL_IF = ('\\N','NULL','')`, databaseName, schemaName, fileFormatName),
 		ff.ChangeNullIf([]string{`\N`, "NULL", ""}),
+	)
+}
+
+func TestFileFormatRecordDelimiter(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET RECORD_DELIMITER = "%v"`, databaseName, schemaName, fileFormatName, snowflake.EscapeString(recordDelimiter)),
+		ff.ChangeRecordDelimiter(recordDelimiter),
+	)
+}
+
+func TestFileFormatFieldDelimiter(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET FIELD_DELIMITER = "%v"`, databaseName, schemaName, fileFormatName, snowflake.EscapeString(fieldDelimiter)),
+		ff.ChangeFieldDelimiter(fieldDelimiter),
+	)
+}
+
+func TestFileFormatFileExtension(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET FILE_EXTENSION = "%v"`, databaseName, schemaName, fileFormatName, snowflake.EscapeString(fileExtension)),
+		ff.ChangeFileExtension(fileExtension),
+	)
+}
+
+func TestFileFormatSkipHeader(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET SKIP_HEADER = %v`, databaseName, schemaName, fileFormatName, skipHeader),
+		ff.ChangeSkipHeader(skipHeader),
+	)
+}
+
+func TestFileFormatSkipBlankLines(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET SKIP_BLANK_LINES = %v`, databaseName, schemaName, fileFormatName, skipBlankLines),
+		ff.ChangeSkipBlankLines(skipBlankLines),
+	)
+}
+
+func TestFileFormatDateFormat(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET DATE_FORMAT = "%v"`, databaseName, schemaName, fileFormatName, snowflake.EscapeString(dateFormat)),
+		ff.ChangeDateFormat(dateFormat),
+	)
+}
+
+func TestFileFormatTimeFormat(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET TIME_FORMAT = "%v"`, databaseName, schemaName, fileFormatName, snowflake.EscapeString(timeFormat)),
+		ff.ChangeTimeFormat(timeFormat),
+	)
+}
+
+func TestFileFormatTimestampFormat(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET TIMESTAMP_FORMAT = "%v"`, databaseName, schemaName, fileFormatName, snowflake.EscapeString(timestampFormat)),
+		ff.ChangeTimestampFormat(timestampFormat),
+	)
+}
+
+func TestFileFormatBinaryFormat(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET BINARY_FORMAT = %v`, databaseName, schemaName, fileFormatName, binaryFormat),
+		ff.ChangeBinaryFormat(binaryFormat),
+	)
+}
+
+func TestFileFormatEscape(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET ESCAPE = "%v"`, databaseName, schemaName, fileFormatName, snowflake.EscapeString(escape)),
+		ff.ChangeEscape(escape),
+	)
+}
+
+func TestFileFormatEscapeUnenclosedField(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET ESCAPE_UNENCLOSED_FIELD = "%v"`, databaseName, schemaName, fileFormatName, snowflake.EscapeString(escapeUnenclosedField)),
+		ff.ChangeEscapeUnenclosedField(escapeUnenclosedField),
+	)
+}
+
+func TestFileFormatFieldOptionallyEnclosedBy(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET FIELD_OPTIONALLY_ENCLOSED_BY = "%v"`, databaseName, schemaName, fileFormatName, snowflake.EscapeString(fieldOptionallyEnclosedBy)),
+		ff.ChangeFieldOptionallyEnclosedBy(fieldOptionallyEnclosedBy),
+	)
+}
+
+func TestFileFormatErrorOnColumnCountMismatch(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET ERROR_ON_COLUMN_COUNT_MISMATCH = %v`, databaseName, schemaName, fileFormatName, errorOnColumnCountMismatch),
+		ff.ChangeErrorOnColumnCountMismatch(errorOnColumnCountMismatch),
+	)
+}
+
+func TestFileFormatReplaceInvalidCharacters(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET REPLACE_INVALID_CHARACTERS = %v`, databaseName, schemaName, fileFormatName, replaceInvalidCharacters),
+		ff.ChangeReplaceInvalidCharacters(replaceInvalidCharacters),
+	)
+}
+
+func TestFileFormatValidateUtf8(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET VALIDATE_UTF8 = %v`, databaseName, schemaName, fileFormatName, validateUtf8),
+		ff.ChangeValidateUtf8(validateUtf8),
+	)
+}
+
+func TestFileFormatEmptyFieldAsNull(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET EMPTY_FIELD_AS_NULL = %v`, databaseName, schemaName, fileFormatName, emptyFieldAsNull),
+		ff.ChangeEmptyFieldAsNull(emptyFieldAsNull),
+	)
+}
+
+func TestFileFormatSkipByteOrderMark(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET SKIP_BYTE_ORDER_MARK = %v`, databaseName, schemaName, fileFormatName, skipByteOrderMark),
+		ff.ChangeSkipByteOrderMark(skipByteOrderMark),
+	)
+}
+
+func TestFileFormatEncoding(t *testing.T) {
+	r := require.New(t)
+	ff := snowflake.FileFormat(fileFormatName, databaseName, schemaName)
+	r.Equal(
+		fmt.Sprintf(`ALTER FILE FORMAT "%v"."%v"."%v" SET ENCODING = "%v"`, databaseName, schemaName, fileFormatName, snowflake.EscapeString(encoding)),
+		ff.ChangeEncoding(encoding),
 	)
 }
 


### PR DESCRIPTION
This PR adds `csv` type support to `snowflake_file_format` resource.

## testing
```bash
$ cat main.tf
resource "snowflake_file_format" "file_format" {
  name = "PETERH_FF"
  database = "PETERH_DB"
  schema = "PUBLIC"
  type = "parquet"
  binary_as_text = true
  comment = "Terraform Snowflake provider development"
}

resource "snowflake_file_format" "file_format2" {
  name = "PETERH_FF2"
  database = "PETERH_DB"
  schema = "PUBLIC"
  type = "csv"
  binary_format = "HEX"
  comment = "Terraform Snowflake provider development"
}
$ terraform plan
...
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # snowflake_file_format.file_format will be created
  + resource "snowflake_file_format" "file_format" {
      + binary_as_text                 = true
      + binary_format                  = (known after apply)
      + comment                        = "Terraform Snowflake provider development"
      + compression                    = (known after apply)
      + database                       = "PETERH_DB"
      + date_format                    = (known after apply)
      + empty_field_as_null            = (known after apply)
      + encoding                       = (known after apply)
      + error_on_column_count_mismatch = (known after apply)
      + escape                         = (known after apply)
      + escape_unenclosed_field        = (known after apply)
      + field_delimiter                = (known after apply)
      + field_optionally_enclosed_by   = (known after apply)
      + file_extension                 = (known after apply)
      + id                             = (known after apply)
      + name                           = "PETERH_FF"
      + null_if                        = (known after apply)
      + record_delimiter               = (known after apply)
      + replace_invalid_characters     = (known after apply)
      + schema                         = "PUBLIC"
      + skip_blank_lines               = (known after apply)
      + skip_byte_order_mark           = (known after apply)
      + skip_header                    = (known after apply)
      + time_format                    = (known after apply)
      + timestamp_format               = (known after apply)
      + trim_space                     = (known after apply)
      + type                           = "parquet"
      + validate_utf8                  = (known after apply)
    }

  # snowflake_file_format.file_format2 will be created
  + resource "snowflake_file_format" "file_format2" {
      + binary_as_text                 = (known after apply)
      + binary_format                  = "HEX"
      + comment                        = "Terraform Snowflake provider development"
      + compression                    = (known after apply)
      + database                       = "PETERH_DB"
      + date_format                    = (known after apply)
      + empty_field_as_null            = (known after apply)
      + encoding                       = (known after apply)
      + error_on_column_count_mismatch = (known after apply)
      + escape                         = (known after apply)
      + escape_unenclosed_field        = (known after apply)
      + field_delimiter                = (known after apply)
      + field_optionally_enclosed_by   = (known after apply)
      + file_extension                 = (known after apply)
      + id                             = (known after apply)
      + name                           = "PETERH_FF2"
      + null_if                        = (known after apply)
      + record_delimiter               = (known after apply)
      + replace_invalid_characters     = (known after apply)
      + schema                         = "PUBLIC"
      + skip_blank_lines               = (known after apply)
      + skip_byte_order_mark           = (known after apply)
      + skip_header                    = (known after apply)
      + time_format                    = (known after apply)
      + timestamp_format               = (known after apply)
      + trim_space                     = (known after apply)
      + type                           = "csv"
      + validate_utf8                  = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.
...
```

## References
* https://docs.snowflake.com/en/sql-reference/sql/create-file-format.html